### PR TITLE
削除ボタンの修正

### DIFF
--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -9,7 +9,9 @@
       </div>
       <div class="post-menus">
         <%= link_to("編集", "/posts/#{@post.id}/edit") %>
-        <%= link_to("削除", "/posts/#{@post.id}/destroy", {method: "post"}) %>
+        <%= form_tag "/posts/#{@post.id}/destroy", { method: :post } do %>
+          <%= submit_tag '削除' %>
+        <% end %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
削除ボタンのリクエストがPOSTではなくGETで行われてしまう事象への対応

◾️原因
`{method: :post}`の動作にはjsが絡んでいるようで、現在このプロジェクトではwebpackerが使用されていないためjsが正しく稼働していないのではないかと思われる。
Railsのバージョンも関係していそう。

◾️対応
form_tagとsubmit_tagを使用して代用